### PR TITLE
[BAHIR-155] TTL to set (created setex) and hset

### DIFF
--- a/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/RedisSink.java
+++ b/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/RedisSink.java
@@ -98,6 +98,7 @@ public class RedisSink<IN> extends RichSinkFunction<IN> {
      * It sets the TTL for a specific key.
      */
     private Integer additionalTTL;
+
     private RedisMapper<IN> redisSinkMapper;
     private RedisCommand redisCommand;
 
@@ -129,7 +130,7 @@ public class RedisSink<IN> extends RichSinkFunction<IN> {
      * Called when new data arrives to the sink, and forwards it to Redis channel.
      * Depending on the specified Redis data type (see {@link RedisDataType}),
      * a different Redis command will be applied.
-     * Available commands are RPUSH, LPUSH, SADD, PUBLISH, SET, PFADD, HSET, ZADD.
+     * Available commands are RPUSH, LPUSH, SADD, PUBLISH, SET, SETEX, PFADD, HSET, ZADD.
      *
      * @param input The incoming data
      */
@@ -137,6 +138,7 @@ public class RedisSink<IN> extends RichSinkFunction<IN> {
     public void invoke(IN input, Context context) throws Exception {
         String key = redisSinkMapper.getKeyFromData(input);
         String value = redisSinkMapper.getValueFromData(input);
+
         Optional<String> optAdditionalKey = redisSinkMapper.getAdditionalKey(input);
         Optional<Integer> optTTLExpire = redisSinkMapper.getAdditionalTTL(input);
 
@@ -152,6 +154,9 @@ public class RedisSink<IN> extends RichSinkFunction<IN> {
                 break;
             case SET:
                 this.redisCommandsContainer.set(key, value);
+                break;
+            case SETEX:
+                this.redisCommandsContainer.setex(key, this.additionalTTL, value);
                 break;
             case PFADD:
                 this.redisCommandsContainer.pfadd(key, value);

--- a/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/RedisSink.java
+++ b/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/RedisSink.java
@@ -94,7 +94,7 @@ public class RedisSink<IN> extends RichSinkFunction<IN> {
     private String additionalKey;
 
     /**
-     * This additional time to live is optional for {@link RedisDataType#HASH}.
+     * This additional time to live is optional for {@link RedisDataType#HASH} and required for {@link RedisCommand#SETEX}.
      * It sets the TTL for a specific key.
      */
     private Integer additionalTTL;
@@ -140,7 +140,7 @@ public class RedisSink<IN> extends RichSinkFunction<IN> {
         String value = redisSinkMapper.getValueFromData(input);
 
         Optional<String> optAdditionalKey = redisSinkMapper.getAdditionalKey(input);
-        Optional<Integer> optTTLExpire = redisSinkMapper.getAdditionalTTL(input);
+        Optional<Integer> optAdditionalTTL = redisSinkMapper.getAdditionalTTL(input);
 
         switch (redisCommand) {
             case RPUSH:
@@ -156,7 +156,7 @@ public class RedisSink<IN> extends RichSinkFunction<IN> {
                 this.redisCommandsContainer.set(key, value);
                 break;
             case SETEX:
-                this.redisCommandsContainer.setex(key, this.additionalTTL, value);
+                this.redisCommandsContainer.setex(key, value, optAdditionalTTL.orElse(this.additionalTTL));
                 break;
             case PFADD:
                 this.redisCommandsContainer.pfadd(key, value);
@@ -172,7 +172,7 @@ public class RedisSink<IN> extends RichSinkFunction<IN> {
                 break;
             case HSET:
                 this.redisCommandsContainer.hset(optAdditionalKey.orElse(this.additionalKey), key, value,
-                        optTTLExpire.orElse(this.additionalTTL));
+                        optAdditionalTTL.orElse(this.additionalTTL));
                 break;
             default:
                 throw new IllegalArgumentException("Cannot process such data type: " + redisCommand);

--- a/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisClusterContainer.java
+++ b/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisClusterContainer.java
@@ -138,6 +138,19 @@ public class RedisClusterContainer implements RedisCommandsContainer, Closeable 
     }
 
     @Override
+    public void setex(final String key, final Integer ttl, final String value) {
+        try {
+            jedisCluster.setex(key, ttl, value);
+        } catch (Exception e) {
+            if (LOG.isErrorEnabled()) {
+                LOG.error("Cannot send Redis message with command SETEX to key {} error message {}",
+                        key, e.getMessage());
+            }
+            throw e;
+        }
+    }
+
+    @Override
     public void pfadd(final String key, final String element) {
         try {
             jedisCluster.pfadd(key, element);

--- a/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisClusterContainer.java
+++ b/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisClusterContainer.java
@@ -23,6 +23,7 @@ import redis.clients.jedis.JedisCluster;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Redis command container if we want to connect to a Redis cluster.
@@ -57,9 +58,10 @@ public class RedisClusterContainer implements RedisCommandsContainer, Closeable 
     }
 
     @Override
-    public void hset(final String key, final String hashField, final String value) {
+    public void hset(final String key, final String hashField, final String value, final Optional<Integer> ttl) {
         try {
             jedisCluster.hset(key, hashField, value);
+            ttl.ifPresent(ttlValue -> jedisCluster.expire(key, ttlValue));
         } catch (Exception e) {
             if (LOG.isErrorEnabled()) {
                 LOG.error("Cannot send Redis message with command HSET to hash {} of key {} error message {}",

--- a/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisClusterContainer.java
+++ b/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisClusterContainer.java
@@ -138,7 +138,7 @@ public class RedisClusterContainer implements RedisCommandsContainer, Closeable 
     }
 
     @Override
-    public void setex(final String key, final Integer ttl, final String value) {
+    public void setex(final String key, final String value, final Integer ttl) {
         try {
             jedisCluster.setex(key, ttl, value);
         } catch (Exception e) {

--- a/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisClusterContainer.java
+++ b/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisClusterContainer.java
@@ -23,7 +23,6 @@ import redis.clients.jedis.JedisCluster;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Objects;
-import java.util.Optional;
 
 /**
  * Redis command container if we want to connect to a Redis cluster.
@@ -58,10 +57,12 @@ public class RedisClusterContainer implements RedisCommandsContainer, Closeable 
     }
 
     @Override
-    public void hset(final String key, final String hashField, final String value, final Optional<Integer> ttl) {
+    public void hset(final String key, final String hashField, final String value, final Integer ttl) {
         try {
             jedisCluster.hset(key, hashField, value);
-            ttl.ifPresent(ttlValue -> jedisCluster.expire(key, ttlValue));
+            if (ttl != null) {
+                jedisCluster.expire(key, ttl);
+            }
         } catch (Exception e) {
             if (LOG.isErrorEnabled()) {
                 LOG.error("Cannot send Redis message with command HSET to hash {} of key {} error message {}",

--- a/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisCommandsContainer.java
+++ b/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisCommandsContainer.java
@@ -18,6 +18,7 @@ package org.apache.flink.streaming.connectors.redis.common.container;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.Optional;
 
 /**
  * The container for all available Redis commands.
@@ -32,15 +33,17 @@ public interface RedisCommandsContainer extends Serializable {
     void open() throws Exception;
 
     /**
-     * Sets field in the hash stored at key to value.
+     * Sets field in the hash stored at key to value, with TTL, if needed.
+     * Setting expire time to key is optional.
      * If key does not exist, a new key holding a hash is created.
      * If field already exists in the hash, it is overwritten.
      *
      * @param key Hash name
      * @param hashField Hash field
      * @param value Hash value
+     * @param ttl Hash expire time
      */
-    void hset(String key, String hashField, String value);
+    void hset(String key, String hashField, String value, Optional<Integer> ttl);
 
     /**
      * Insert the specified value at the tail of the list stored at key.

--- a/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisCommandsContainer.java
+++ b/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisCommandsContainer.java
@@ -18,7 +18,6 @@ package org.apache.flink.streaming.connectors.redis.common.container;
 
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.Optional;
 
 /**
  * The container for all available Redis commands.
@@ -91,7 +90,16 @@ public interface RedisCommandsContainer extends Serializable {
      */
     void set(String key, String value);
 
-    void setex(String key, Integer ttl, String value);
+    /**
+     * Set key to hold the string value, with a time to live (TTL). If key already holds a value,
+     * it is overwritten, regardless of its type. Any previous time to live associated with the key is
+     * reset on successful SETEX operation.
+     *
+     * @param key the key name in which value to be set
+     * @param value the value
+     * @param ttl time to live (TTL)
+     */
+    void setex(String key, String value, Integer ttl);
 
     /**
      * Adds all the element arguments to the HyperLogLog data structure

--- a/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisCommandsContainer.java
+++ b/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisCommandsContainer.java
@@ -91,6 +91,8 @@ public interface RedisCommandsContainer extends Serializable {
      */
     void set(String key, String value);
 
+    void setex(String key, Integer ttl, String value);
+
     /**
      * Adds all the element arguments to the HyperLogLog data structure
      * stored at the variable name specified as first argument.

--- a/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisCommandsContainer.java
+++ b/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisCommandsContainer.java
@@ -43,7 +43,7 @@ public interface RedisCommandsContainer extends Serializable {
      * @param value Hash value
      * @param ttl Hash expire time
      */
-    void hset(String key, String hashField, String value, Optional<Integer> ttl);
+    void hset(String key, String hashField, String value, Integer ttl);
 
     /**
      * Insert the specified value at the tail of the list stored at key.

--- a/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisContainer.java
+++ b/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisContainer.java
@@ -24,8 +24,7 @@ import redis.clients.jedis.JedisSentinelPool;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.Objects; 
 
 /**
  * Redis command container if we want to connect to a single Redis server or to Redis sentinels
@@ -87,13 +86,13 @@ public class RedisContainer implements RedisCommandsContainer, Closeable {
     }
 
     @Override
-    public void hset(final String key, final String hashField, final String value, final Optional<Integer> ttl) {
+    public void hset(final String key, final String hashField, final String value, final Integer ttl) {
         Jedis jedis = null;
         try {
             jedis = getInstance();
             jedis.hset(key, hashField, value);
-            if (ttl.isPresent()) {
-                jedis.expire(key, ttl.get());
+            if (ttl != null) {
+                jedis.expire(key, ttl);
             }
         } catch (Exception e) {
             if (LOG.isErrorEnabled()) {

--- a/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisContainer.java
+++ b/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisContainer.java
@@ -25,6 +25,7 @@ import redis.clients.jedis.JedisSentinelPool;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Redis command container if we want to connect to a single Redis server or to Redis sentinels
@@ -86,11 +87,14 @@ public class RedisContainer implements RedisCommandsContainer, Closeable {
     }
 
     @Override
-    public void hset(final String key, final String hashField, final String value) {
+    public void hset(final String key, final String hashField, final String value, final Optional<Integer> ttl) {
         Jedis jedis = null;
         try {
             jedis = getInstance();
             jedis.hset(key, hashField, value);
+            if (ttl.isPresent()) {
+                jedis.expire(key, ttl.get());
+            }
         } catch (Exception e) {
             if (LOG.isErrorEnabled()) {
                 LOG.error("Cannot send Redis message with command HSET to key {} and hashField {} error message {}",

--- a/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisContainer.java
+++ b/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisContainer.java
@@ -24,7 +24,7 @@ import redis.clients.jedis.JedisSentinelPool;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.Objects; 
+import java.util.Objects;
 
 /**
  * Redis command container if we want to connect to a single Redis server or to Redis sentinels
@@ -183,6 +183,23 @@ public class RedisContainer implements RedisCommandsContainer, Closeable {
             if (LOG.isErrorEnabled()) {
                 LOG.error("Cannot send Redis message with command SET to key {} error message {}",
                     key, e.getMessage());
+            }
+            throw e;
+        } finally {
+            releaseInstance(jedis);
+        }
+    }
+
+    @Override
+    public void setex(final String key, final Integer ttl, final String value) {
+        Jedis jedis = null;
+        try {
+            jedis = getInstance();
+            jedis.setex(key, ttl, value);
+        } catch (Exception e) {
+            if (LOG.isErrorEnabled()) {
+                LOG.error("Cannot send Redis message with command SETEX to key {} error message {}",
+                        key, e.getMessage());
             }
             throw e;
         } finally {

--- a/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisContainer.java
+++ b/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisContainer.java
@@ -191,7 +191,7 @@ public class RedisContainer implements RedisCommandsContainer, Closeable {
     }
 
     @Override
-    public void setex(final String key, final Integer ttl, final String value) {
+    public void setex(final String key, final String value, final Integer ttl) {
         Jedis jedis = null;
         try {
             jedis = getInstance();

--- a/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/mapper/RedisCommand.java
+++ b/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/mapper/RedisCommand.java
@@ -45,6 +45,8 @@ public enum RedisCommand {
      */
     SET(RedisDataType.STRING),
 
+    SETEX(RedisDataType.STRING),
+
     /**
      * Adds the element to the HyperLogLog data structure stored at the variable name specified as first argument.
      */

--- a/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/mapper/RedisCommand.java
+++ b/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/mapper/RedisCommand.java
@@ -45,6 +45,10 @@ public enum RedisCommand {
      */
     SET(RedisDataType.STRING),
 
+    /**
+     * Set key to hold the string value, with a time to live (TTL). If key already holds a value,
+     * it is overwritten, regardless of its type.
+     */
     SETEX(RedisDataType.STRING),
 
     /**

--- a/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/mapper/RedisCommandDescription.java
+++ b/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/mapper/RedisCommandDescription.java
@@ -22,7 +22,7 @@ import java.util.Objects;
 /**
  * The description of the command type. This must be passed while creating new {@link RedisMapper}.
  * <p>When creating descriptor for the group of {@link RedisDataType#HASH} and {@link RedisDataType#SORTED_SET},
- * you need to use first constructor {@link #RedisCommandDescription(RedisCommand, String)}.
+ * you need to use first constructor {@link #RedisCommandDescription(RedisCommand, String, Integer)}.
  * If the {@code additionalKey} is {@code null} it will throw {@code IllegalArgumentException}
  *
  * <p>When {@link RedisCommand} is not in group of {@link RedisDataType#HASH} and {@link RedisDataType#SORTED_SET}
@@ -46,6 +46,13 @@ public class RedisCommandDescription implements Serializable {
     private String additionalKey;
 
     /**
+     * This additional key is optional for the group {@link RedisDataType#HASH}.
+     * In this case, we need four variables.
+     * <p>For {@link RedisDataType#HASH} we need hash name, hash key, element and TTL.
+     */
+    private Integer additionalTTL;
+
+    /**
      * Use this constructor when data type is {@link RedisDataType#HASH} or {@link RedisDataType#SORTED_SET}.
      * If different data type is specified, {@code additionalKey} is ignored.
      * @param redisCommand the redis command type {@link RedisCommand}
@@ -55,6 +62,7 @@ public class RedisCommandDescription implements Serializable {
         Objects.requireNonNull(redisCommand, "Redis command type can not be null");
         this.redisCommand = redisCommand;
         this.additionalKey = additionalKey;
+        this.additionalTTL = Integer.MAX_VALUE;
 
         if (redisCommand.getRedisDataType() == RedisDataType.HASH ||
             redisCommand.getRedisDataType() == RedisDataType.SORTED_SET) {
@@ -65,12 +73,33 @@ public class RedisCommandDescription implements Serializable {
     }
 
     /**
+     * Use this constructor when data type is {@link RedisDataType#HASH} with a additional TTL.
+     * If different data type is specified, {@code additionalKey} is ignored.
+     * @param redisCommand the redis command type {@link RedisCommand}
+     * @param additionalKey additional key for Hash data type
+     * @param additionalTTL additional TTL optional for Hash data type
+     */
+    public RedisCommandDescription(RedisCommand redisCommand, String additionalKey, Integer additionalTTL) {
+        Objects.requireNonNull(redisCommand, "Redis command type can not be null");
+        this.redisCommand = redisCommand;
+        this.additionalKey = additionalKey;
+        this.additionalTTL = additionalTTL;
+
+        if (redisCommand.getRedisDataType() == RedisDataType.HASH ||
+            redisCommand.getRedisDataType() == RedisDataType.SORTED_SET) {
+            if (additionalKey == null) {
+                throw new IllegalArgumentException("Hash should have additional key");
+            }
+        }
+    }
+
+    /**
      * Use this constructor when command type is not in group {@link RedisDataType#HASH} or {@link RedisDataType#SORTED_SET}.
      *
      * @param redisCommand the redis data type {@link RedisCommand}
      */
     public RedisCommandDescription(RedisCommand redisCommand) {
-        this(redisCommand, null);
+        this(redisCommand, null, null);
     }
 
     /**
@@ -87,7 +116,12 @@ public class RedisCommandDescription implements Serializable {
      *
      * @return the additional key
      */
-    public String getAdditionalKey() {
-        return additionalKey;
-    }
+    public String getAdditionalKey() { return additionalKey; }
+
+    /**
+     * Returns the additional time to live (TTL) if data type is {@link RedisDataType#HASH}.
+     *
+     * @return the additional TTL
+     */
+    public Integer getAdditionalTTL() { return additionalTTL; }
 }

--- a/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/mapper/RedisCommandDescription.java
+++ b/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/mapper/RedisCommandDescription.java
@@ -53,26 +53,6 @@ public class RedisCommandDescription implements Serializable {
     private Integer additionalTTL;
 
     /**
-     * Use this constructor when data type is {@link RedisDataType#HASH} or {@link RedisDataType#SORTED_SET}.
-     * If different data type is specified, {@code additionalKey} is ignored.
-     * @param redisCommand the redis command type {@link RedisCommand}
-     * @param additionalKey additional key for Hash and Sorted set data type
-     */
-    public RedisCommandDescription(RedisCommand redisCommand, String additionalKey) {
-        Objects.requireNonNull(redisCommand, "Redis command type can not be null");
-        this.redisCommand = redisCommand;
-        this.additionalKey = additionalKey;
-        this.additionalTTL = Integer.MAX_VALUE;
-
-        if (redisCommand.getRedisDataType() == RedisDataType.HASH ||
-            redisCommand.getRedisDataType() == RedisDataType.SORTED_SET) {
-            if (additionalKey == null) {
-                throw new IllegalArgumentException("Hash and Sorted Set should have additional key");
-            }
-        }
-    }
-
-    /**
      * Use this constructor when data type is {@link RedisDataType#HASH} with a additional TTL.
      * If different data type is specified, {@code additionalKey} is ignored.
      * @param redisCommand the redis command type {@link RedisCommand}
@@ -91,6 +71,16 @@ public class RedisCommandDescription implements Serializable {
                 throw new IllegalArgumentException("Hash should have additional key");
             }
         }
+    }
+
+    /**
+     * Use this constructor when data type is {@link RedisDataType#HASH} or {@link RedisDataType#SORTED_SET}.
+     * If different data type is specified, {@code additionalKey} is ignored.
+     * @param redisCommand the redis command type {@link RedisCommand}
+     * @param additionalKey additional key for Hash and Sorted set data type
+     */
+    public RedisCommandDescription(RedisCommand redisCommand, String additionalKey) {
+        this(redisCommand, additionalKey, null);
     }
 
     /**

--- a/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/mapper/RedisCommandDescription.java
+++ b/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/mapper/RedisCommandDescription.java
@@ -71,16 +71,32 @@ public class RedisCommandDescription implements Serializable {
                 throw new IllegalArgumentException("Hash should have additional key");
             }
         }
+
+        if (redisCommand.equals(RedisCommand.SETEX)) {
+            if (additionalTTL == null) {
+                throw new IllegalArgumentException("SETEX command should have time to live (TTL)");
+            }
+        }
     }
 
     /**
-     * Use this constructor when data type is {@link RedisDataType#HASH} or {@link RedisDataType#SORTED_SET}.
+     * Use this constructor when data type is {@link RedisDataType#HASH} (without TTL) or {@link RedisDataType#SORTED_SET}.
      * If different data type is specified, {@code additionalKey} is ignored.
      * @param redisCommand the redis command type {@link RedisCommand}
      * @param additionalKey additional key for Hash and Sorted set data type
      */
     public RedisCommandDescription(RedisCommand redisCommand, String additionalKey) {
         this(redisCommand, additionalKey, null);
+    }
+
+    /**
+     * Use this constructor when using SETEX command {@link RedisDataType#STRING}.
+     * This command requires a TTL. Throws {@link IllegalArgumentException} if it is null.
+     * @param redisCommand the redis command type {@link RedisCommand}
+     * @param additionalTTL additional TTL required for SETEX command
+     */
+    public RedisCommandDescription(RedisCommand redisCommand, Integer additionalTTL) {
+        this(redisCommand, null, additionalTTL);
     }
 
     /**

--- a/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/mapper/RedisCommandDescription.java
+++ b/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/mapper/RedisCommandDescription.java
@@ -22,10 +22,12 @@ import java.util.Objects;
 /**
  * The description of the command type. This must be passed while creating new {@link RedisMapper}.
  * <p>When creating descriptor for the group of {@link RedisDataType#HASH} and {@link RedisDataType#SORTED_SET},
- * you need to use first constructor {@link #RedisCommandDescription(RedisCommand, String, Integer)}.
+ * you need to use first constructor {@link #RedisCommandDescription(RedisCommand, String)}.
  * If the {@code additionalKey} is {@code null} it will throw {@code IllegalArgumentException}
  *
- * <p>When {@link RedisCommand} is not in group of {@link RedisDataType#HASH} and {@link RedisDataType#SORTED_SET}
+ * If command is {@link RedisCommand#SETEX}, its required to use TTL. The proper constructor is {@link #RedisCommandDescription(RedisCommand, Integer)}.
+ *
+ * <p>When {@link RedisCommand} is not in group of {@link RedisDataType#HASH} and {@link RedisDataType#SORTED_SET}, also not {@link RedisCommand#SETEX},
  * you can use second constructor {@link #RedisCommandDescription(RedisCommand)}
  */
 public class RedisCommandDescription implements Serializable {
@@ -38,7 +40,7 @@ public class RedisCommandDescription implements Serializable {
      * This additional key is needed for the group {@link RedisDataType#HASH} and {@link RedisDataType#SORTED_SET}.
      * Other {@link RedisDataType} works only with two variable i.e. name of the list and value to be added.
      * But for {@link RedisDataType#HASH} and {@link RedisDataType#SORTED_SET} we need three variables.
-     * <p>For {@link RedisDataType#HASH} we need hash name, hash key and element.
+     * <p>For {@link RedisDataType#HASH} we need hash name, hash key and element. Its possible to use TTL.
      * {@link #getAdditionalKey()} used as hash name for {@link RedisDataType#HASH}
      * <p>For {@link RedisDataType#SORTED_SET} we need set name, the element and it's score.
      * {@link #getAdditionalKey()} used as set name for {@link RedisDataType#SORTED_SET}
@@ -46,15 +48,19 @@ public class RedisCommandDescription implements Serializable {
     private String additionalKey;
 
     /**
-     * This additional key is optional for the group {@link RedisDataType#HASH}.
-     * In this case, we need four variables.
-     * <p>For {@link RedisDataType#HASH} we need hash name, hash key, element and TTL.
+     * This additional key is optional for the group {@link RedisDataType#HASH}, required for {@link RedisCommand#SETEX}.
+     * For the other types and commands, its not used.
+     * <p>For {@link RedisDataType#HASH} we need hash name, hash key and element. Its possible to use TTL.
+     * {@link #getAdditionalTTL()} used as time to live (TTL) for {@link RedisDataType#HASH}
+     * <p>For {@link RedisCommand#SETEX}, we need key, value and time to live (TTL).
      */
     private Integer additionalTTL;
 
     /**
-     * Use this constructor when data type is {@link RedisDataType#HASH} with a additional TTL.
-     * If different data type is specified, {@code additionalKey} is ignored.
+     * Default constructor for {@link RedisCommandDescription}.
+     * For {@link RedisDataType#HASH} and {@link RedisDataType#SORTED_SET} data types, {@code additionalKey} is required.
+     * For {@link RedisCommand#SETEX} command, {@code additionalTTL} is required.
+     * In both cases, if the respective variables are not provided, it throws an {@link IllegalArgumentException}
      * @param redisCommand the redis command type {@link RedisCommand}
      * @param additionalKey additional key for Hash data type
      * @param additionalTTL additional TTL optional for Hash data type
@@ -68,7 +74,7 @@ public class RedisCommandDescription implements Serializable {
         if (redisCommand.getRedisDataType() == RedisDataType.HASH ||
             redisCommand.getRedisDataType() == RedisDataType.SORTED_SET) {
             if (additionalKey == null) {
-                throw new IllegalArgumentException("Hash should have additional key");
+                throw new IllegalArgumentException("Hash and Sorted Set should have additional key");
             }
         }
 

--- a/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/mapper/RedisMapper.java
+++ b/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/mapper/RedisMapper.java
@@ -75,4 +75,15 @@ public interface RedisMapper<T> extends Function, Serializable {
     default Optional<String> getAdditionalKey(T data) {
         return Optional.empty();
     }
+
+    /**
+     * Extracts the additional time to live (TTL) for data as an {@link Optional<Integer>}.
+     * The default implementation returns an empty Optional.
+     *
+     * @param data
+     * @return Optional
+     */
+    default Optional<Integer> getAdditionalTTL(T data) {
+        return Optional.empty();
+    }
 }

--- a/flink-connector-redis/src/test/java/org/apache/flink/streaming/connectors/redis/common/mapper/RedisDataTypeDescriptionTest.java
+++ b/flink-connector-redis/src/test/java/org/apache/flink/streaming/connectors/redis/common/mapper/RedisDataTypeDescriptionTest.java
@@ -31,6 +31,12 @@ public class RedisDataTypeDescriptionTest extends TestLogger {
         redisCommandMapper.getCommandDescription();
     }
 
+    @Test(expected=IllegalArgumentException.class)
+    public void shouldThrowExceptionIfAdditionalTTLIsNotGivenForStringDataTypeWithTTL(){
+        RedisSinkITCase.RedisCommandMapper redisCommandMapper = new RedisSinkITCase.RedisCommandMapper(RedisCommand.SETEX);
+        redisCommandMapper.getCommandDescription();
+    }
+
     @Test
     public void shouldReturnNullForAdditionalDataType(){
         RedisSinkITCase.RedisCommandMapper redisCommandMapper = new RedisSinkITCase.RedisCommandMapper(RedisCommand.LPUSH);


### PR DESCRIPTION
This PR introduces the possibility to add a TTL to HSET and SET.
With this new functionality, we're able to expire specific key.
`hset` call executes `jedis.hset`, and if TTL is given, calls `jedis.expire`.

